### PR TITLE
Removed image output from readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ This guide details the initial setup and basic usage of the [SfMarkdownViewer]()
     }  
 ```
 
-### Output
-<img width="1397" height="715" alt="maui-markdown-viewer-gettingstarted" src="https://github.com/user-attachments/assets/cfa2c6aa-998a-4259-83ff-f6428d788b01" />
-
 ## Troubleshooting
 
 ### Path Too Long Exception


### PR DESCRIPTION
**Description** 

- Removed images in readme 

In markdown viewer video, we have shared this repo readme as source for markdown viewer control. Currently, the image using html format not supported. Facing below issue, hence removing image from readme

<img width="191" height="344" alt="image" src="https://github.com/user-attachments/assets/4ff21492-6b2e-4e7a-9b98-5cc8b919e65a" />
